### PR TITLE
Fix link alignment on Devise View

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,24 +4,26 @@
   <div class="field">
     <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email' %>
   </div>
-
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
   <div class="field">
     <%= f.password_field :current_password, autocomplete: "off", class: 'form-control', placeholder: 'Current Password' %>
   </div>
-
   <div class="field">
     <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'New Password' %>
   </div>
-
   <div class="field">
     <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm New Password' %>
   </div>
   <div class="actions">
     <%= f.submit "Update", class: 'btn btn-lg btn-primary btn-block' %>
   </div>
-  <h3>Danger Zone</h3>
-  <p><%= button_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger' %></p>
+  <div>
+    <hr />
+    <h3>Danger Zone</h3>
+    <%= button_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger' %>
+    <hr />
+    <%= link_to "Back to dashboard", readings_path %>
+  </div>
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,6 +14,5 @@
     <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder:'Password confirmation'%>
   </div>
     <%= f.submit "Sign up", class: 'btn btn-lg btn-primary btn-block'  %>
-  </div>
 <%= render "devise/shared/links" %>
 <% end %>


### PR DESCRIPTION
Previously, two Devise pages (edit registration and new registration) had problems with the postion of links. Edit registration's link was missing and once added, it would show up misaligned. New registration's link did exist but it was misaligned.
