### PR TITLE
Fix regression with Devise View style

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,11 +1,11 @@
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, html: { class: 'form-signin'}) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, html: { class: 'form-devise'}) do |f| %>
   <%= devise_error_messages! %>
   <h2>Forgot your password?</h2>
   <div class="field">
     <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email' %>
   </div>
   <div class="actions">
-    <%= f.submit "Update Password", class: 'btn btn-lg btn-primary btn-lg' %>
+    <%= f.submit "Update Password", class: 'btn btn-lg btn-primary' %>
   </div>
   <%= render "devise/shared/links" %>
 <% end %>


### PR DESCRIPTION
When a css class was renamed, one Action in the Devise View wasn't updated. The affected Action was the 'Forget my password' page. The result was the 'Forget my password' form wasn't appropriated centered. The commit that introduced the regression was: 211245b83b037cb59475fec2e6972416d0ae31ff.
