### PR TITLE
Fix bug with edit registration

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,24 +1,26 @@
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, html: { class: 'form-devise'}) do |f| %>
-  <%= devise_error_messages! %>
-  <h2>Edit <%= resource_name.to_s.humanize %></h2>
-  <div class="field">
-    <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email' %>
-  </div>
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+<div class="form-devise">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= devise_error_messages! %>
+    <h2>Edit <%= resource_name.to_s.humanize %></h2>
+    <div class="field">
+      <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email' %>
+    </div>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+    <div class="field">
+      <%= f.password_field :current_password, autocomplete: "off", class: 'form-control', placeholder: 'Current Password' %>
+    </div>
+    <div class="field">
+      <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'New Password' %>
+    </div>
+    <div class="field">
+      <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm New Password' %>
+    </div>
+    <div class="actions">
+      <%= f.submit "Update", class: 'btn btn-lg btn-primary btn-block' %>
+    </div>
   <% end %>
-  <div class="field">
-    <%= f.password_field :current_password, autocomplete: "off", class: 'form-control', placeholder: 'Current Password' %>
-  </div>
-  <div class="field">
-    <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'New Password' %>
-  </div>
-  <div class="field">
-    <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm New Password' %>
-  </div>
-  <div class="actions">
-    <%= f.submit "Update", class: 'btn btn-lg btn-primary btn-block' %>
-  </div>
   <div>
     <hr />
     <h3>Danger Zone</h3>
@@ -26,4 +28,4 @@
     <hr />
     <%= link_to "Back to dashboard", readings_path %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
Previously, on the Edit Registration page, upon clicking the update button, the user's account would be deleted instead of updated. Bjorn was the first to notice the bug. The solution was to move the delete button outside of the the form element deals with registration updates.
