### PR TITLE
format date on readings table

### DIFF
--- a/app/views/readings/index.html.erb
+++ b/app/views/readings/index.html.erb
@@ -31,7 +31,7 @@
             <tbody>
               <% @readings.each do |reading, cost| %>
                 <tr>
-                  <td><%= reading.reading_date %></td>
+                  <td><%= reading.reading_date.strftime("%m-%d-%Y") %></td>
                   <td><%= reading.reading %></td>
                   <td><%= number_to_currency(cost) %></td>
                   <td><%= link_to 'Show', reading %></td>


### PR DESCRIPTION
Change format to mm-dd-yyyy instead of yyyy-mm-dd on readings table
